### PR TITLE
Add HIE yaml

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,6 @@
+cradle:
+  cabal:
+    - path: "./compiler"
+      component: "exe:zokka"
+    - path: "./tests/TestMain.hs"
+      component: "test:zokka-tests"


### PR DESCRIPTION
For some reason this seems to be necessary, otherwise we get the following error in VSCode with HLS:

```
Error: cabal: Ambiguous target
'/home/code/zelm-compiler/compiler/src/Generate/JavaScript.hs'.
It could be:
zokka-tests:compiler/src/Generate/JavaScript (file)
zokka:compiler/src/Generate/JavaScript (file)
```

Note that this has nothing to do with Zokka itself and is included purely for developer convenience (so the rest of this PR template is ignored).
