### PR TITLE
Make note of compiler oddities

### DIFF
--- a/ODDITIES_IN_COMPILER.md
+++ b/ODDITIES_IN_COMPILER.md
@@ -1,0 +1,4 @@
++ The current Elm compiler sends POST requests to the Elm package server for
+  everything, including things that could just be GETs (e.g. requesting JSON)
++ There is a `DefineTailFunc` constructor in `AST.Optimized.Node`. This does not
+  seem to be actually constructed anywhere (only destructed).


### PR DESCRIPTION
This is useful just as reference when building things

Not including any other info in the usual template because these are just some internal docs.